### PR TITLE
Calculator improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Disable directly solving equations without command sent to groups
 - Fix not shortening solutions form the calculator
 - Fix message too long for Telegram, for too long solutions from the calculator
+- Remove all `True` and `False` before trying to calculate so a message with just "true" doesn't get returned

--- a/xenian_bot/commands/calculator.py
+++ b/xenian_bot/commands/calculator.py
@@ -64,6 +64,7 @@ class Calculator(BaseCommand):
         """
         equation = equation or update.message.text
         equation = re.sub('["\']', '', equation)
+        equation = re.sub('(true|false)', '', equation, flags=re.IGNORECASE)
         message = ''
         try:
             result = eval(equation, {"__builtins__": None}, self.safe_dict)


### PR DESCRIPTION
resolves #2 

Fixes and improvements in calculator module

### Added
- Add `/calc EQUATION` command to calculate equations inside groups

### Changed
- Run math function asynchronous
- Disable directly solving equations without command sent to groups
- Fix not shortening solutions form the calculator
- Fix message too long for Telegram, for too long solutions from the calculator
- Remove all `True` and `False` before trying to calculate so a message with just "true" doesn't get returned
