### PR TITLE
Tesseract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Group setting for commands
 - Use MongoDB as database, configuration must be set in settings.py
 - Create collection in database with all user, messages and chats
+- `/itt [-l LANG]` - Image to Text: Extract text from images
+- `/itt_lang` - Languages for ItT: Available languages for Image to Text
 
 ### Changes
 - Fix command default options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Create collection in database with all user, messages and chats
 - `/itt [-l LANG]` - Image to Text: Extract text from images
 - `/itt_lang` - Languages for ItT: Available languages for Image to Text
+- `/translate_image [TEXT] [-lf LANG] [-lt LANG]`  - Image to Text Translation: Extract text from images and translate it. `-lf` (default: detect, /itt_lang) language on image, to `-lt` (default: en, normal language codes) language.
 
 ### Changes
 - Fix command default options
 - Use Filters.all as default for MessageHandler
+- Yandex translate got new function for itself, it is used by the `/translate` and `/itt_translate` command.
 
 
 ## [1.1.2] - 2018-02-04

--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,8 @@ instabot = "*"
 gtts = "*"
 "yandex.translate" = "*"
 pymongo = "*"
+pytesseract = "*"
+pillow = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a73e867159a83c238d5825e7bce160e7e8af534955d4d7667eea4b932ab14122"
+            "sha256": "413f40db31e16f4c35960d9db1e38486483a7bda8453384fdce6c93c202aafa7"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -115,6 +115,7 @@
                 "sha256:87f837459c3c78d75cb4f5aadf08a7104db15e8c7618a5c732e60f252279c7a6",
                 "sha256:df9083a992b17a28cd4251a3f5c879e0198bb26c9e808c4647e0a18739f1d11d"
             ],
+            "markers": "platform_python_implementation != 'PyPy'",
             "version": "==1.11.4"
         },
         "chardet": {
@@ -427,6 +428,12 @@
                 "sha256:e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9"
             ],
             "version": "==1.2.1"
+        },
+        "pytesseract": {
+            "hashes": [
+                "sha256:35035b0a69a789224d1e981d95453d644c95f8bf869372787f2164b9872d597f"
+            ],
+            "version": "==0.2.0"
         },
         "python-dateutil": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ If you like this bot you can rate it [here](https://telegram.me/storebot?start=x
 - `/rules_remove` - Remove Rules: Remove rules for this group (Group Only)
 - `/tty [TEXT] [-l LANG]` - Text to speech: Convert text the given text or the message replied to, to text. Use `-l` to define a language, like de, en or ru
 - `/translate [TEXT] [-lf LANG] [-lt LANG]` - Translate a reply or a given text from `-lf` (default: detect) language to `-lt` (default: en) language
+- `/itt [-l LANG]` - Image to Text: Extract text from images
+- `/itt_lang` - Languages for ItT: Available languages for Image to Text
 - More will come soon if you have any ideas or stuff you want: [Contributions](#contributions)
 
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you like this bot you can rate it [here](https://telegram.me/storebot?start=x
 - `/translate [TEXT] [-lf LANG] [-lt LANG]` - Translate a reply or a given text from `-lf` (default: detect) language to `-lt` (default: en) language
 - `/itt [-l LANG]` - Image to Text: Extract text from images
 - `/itt_lang` - Languages for ItT: Available languages for Image to Text
+- `/translate_image [TEXT] [-lf LANG] [-lt LANG]`  - Image to Text Translation: Extract text from images and translate it. `-lf` (default: detect, /itt_lang) language on image, to `-lt` (default: en, normal language codes) language.
 - More will come soon if you have any ideas or stuff you want: [Contributions](#contributions)
 
 

--- a/xenian_bot/commands/__init__.py
+++ b/xenian_bot/commands/__init__.py
@@ -12,3 +12,4 @@ from .calculator import *
 from .group_management import *
 from .google import *
 from .yandex import *
+from .image_to_text import *

--- a/xenian_bot/commands/image_to_text.py
+++ b/xenian_bot/commands/image_to_text.py
@@ -1,0 +1,101 @@
+import io
+
+import pytesseract
+from PIL import Image
+from pytesseract import TesseractError
+from telegram import Bot, ParseMode, Update
+from telegram.ext import run_async
+
+from xenian_bot.settings import IMAGE_TO_TEXT_LANG
+from xenian_bot.utils import get_option_from_string
+from .base import BaseCommand
+
+__all__ = ['image_to_text']
+
+
+class ImageToText(BaseCommand):
+    """Extract text from images
+    """
+
+    def __init__(self):
+        self.commands = [
+            {
+                'command': self.image_to_text,
+                'command_name': 'itt',
+                'title': 'Image to Text',
+                'description': 'Extract text from images',
+                'args': '[-l LANG]'
+            },
+            {
+                'command': self.available_languages,
+                'command_name': 'itt_lang',
+                'title': 'Languages for ItT',
+                'description': 'Available languages for Image to Text',
+            },
+        ]
+
+        super(ImageToText, self).__init__()
+
+    @run_async
+    def available_languages(self, bot: Bot, update: Update):
+        """Print available languages for image to text
+
+        Args:
+            bot (:obj:`telegram.bot.Bot`): Telegram Api Bot Object.
+            update (:obj:`telegram.update.Update`): Telegram Api Update Object
+        """
+        text = '*Available languages for Image to Text(/itt)*:\n\n'
+        for short, name in IMAGE_TO_TEXT_LANG:
+            text += '`{}` -> {}\n'.format(short, name)
+
+        update.message.reply_text(text, parse_mode=ParseMode.MARKDOWN)
+
+    @run_async
+    def image_to_text(self, bot: Bot, update: Update):
+        """Extract text from images
+
+        Args:
+            bot (:obj:`telegram.bot.Bot`): Telegram Api Bot Object.
+            update (:obj:`telegram.update.Update`): Telegram Api Update Object
+        """
+        reply_to_message = update.message.reply_to_message
+        if not reply_to_message or not reply_to_message.photo:
+            update.message.reply_text('You have to reply to an image.')
+            return
+
+        lang, text = get_option_from_string('l', update.message.text)
+
+        photo = bot.getFile(reply_to_message.photo[-1].file_id)
+        with io.BytesIO() as image_buffer:
+            photo.download(out=image_buffer)
+
+            pil_image = Image.open(image_buffer)
+            try:
+                text = self.extract_text(pil_image, lang)
+            except TesseractError:
+                update.message.reply_text('Either the given language is not supported or there was another error.\n'
+                                          'See all languages with /itt_lang.')
+
+        if text:
+            reply = 'This text was found: {}'.format(text)
+        else:
+            reply = 'No text was found. Make sure that the text is not rotated and good readable.'
+
+        update.message.reply_text(reply)
+
+    def extract_text(self, image: object or Image, lang: str = None) -> str:
+        """Extract text from an image
+
+        Works with tesseract
+
+        Args:
+            image (:obj:`Object` or :obj:`PIL.Image`): File like object or PIL Image
+            lang (:obj:`str`): What is the language on the image
+
+        Returns:
+            :obj:`str`: Text found in image
+        """
+        return pytesseract.image_to_string(image, lang=lang)
+
+
+image_to_text = ImageToText()

--- a/xenian_bot/commands/image_to_text.py
+++ b/xenian_bot/commands/image_to_text.py
@@ -8,6 +8,7 @@ from telegram.ext import run_async
 
 from xenian_bot.settings import IMAGE_TO_TEXT_LANG
 from xenian_bot.utils import get_option_from_string
+from . import yandex
 from .base import BaseCommand
 
 __all__ = ['image_to_text']
@@ -25,6 +26,14 @@ class ImageToText(BaseCommand):
                 'title': 'Image to Text',
                 'description': 'Extract text from images',
                 'args': '[-l LANG]'
+            },
+            {
+                'command': self.image_to_text_translate,
+                'command_name': 'itt_translate',
+                'title': 'Image to Text Translation',
+                'description': 'Extract text from images and translate it. `-lf` (default: detect, /itt_lang) language '
+                               'on image, to `-lt` (default: en, normal language codes) language.',
+                'args': '[TEXT] [-lf LANG] [-lt LANG]'
             },
             {
                 'command': self.available_languages,
@@ -82,6 +91,46 @@ class ImageToText(BaseCommand):
             reply = 'No text was found. Make sure that the text is not rotated and good readable.'
 
         update.message.reply_text(reply)
+
+    @run_async
+    def image_to_text_translate(self, bot: Bot, update: Update):
+        """Extract text from images and translate it
+
+        Args:
+            bot (:obj:`telegram.bot.Bot`): Telegram Api Bot Object.
+            update (:obj:`telegram.update.Update`): Telegram Api Update Object
+        """
+        reply_to_message = update.message.reply_to_message
+        if not reply_to_message or not reply_to_message.photo:
+            update.message.reply_text('You have to reply to an image.')
+            return
+
+        lang_from, text = get_option_from_string('lf', update.message.text)
+        lang_to, text = get_option_from_string('lt', update.message.text)
+
+        photo = bot.getFile(reply_to_message.photo[-1].file_id)
+        with io.BytesIO() as image_buffer:
+            photo.download(out=image_buffer)
+
+            pil_image = Image.open(image_buffer)
+            try:
+                text = self.extract_text(pil_image, lang_from)
+            except TesseractError:
+                update.message.reply_text('Either the given language is not supported or there was another error.\n'
+                                          'See all languages with /itt_lang.')
+
+        if text:
+            translated = yandex.translate_text(text, lang_to=lang_to)
+            reply = ('*Found Text:*\n{text}\n\n*Translation:* `{direction}` \n\n{translated}\n\n- Powered by '
+                     'Yandex.Translate').format(
+                text=text,
+                direction=translated['lang'],
+                translated=translated['text'][0]
+            )
+        else:
+            reply = 'No text was found. Make sure that the text is not rotated and good readable.'
+
+        update.message.reply_text(reply, parse_mode=ParseMode.MARKDOWN)
 
     def extract_text(self, image: object or Image, lang: str = None) -> str:
         """Extract text from an image

--- a/xenian_bot/settings.example.py
+++ b/xenian_bot/settings.example.py
@@ -45,3 +45,28 @@ MONGODB_CONFIGURATION = {
     'port': 'PORT_OF_YOUR_DB_AS_INT',  # default: 27017
     'db_name': 'DATABASE_NAME',
 }
+
+IMAGE_TO_TEXT_LANG = [  # All languages available for tesseract: https://github.com/tesseract-ocr/tessdata_best
+    ('afr', 'Afrikaans'), ('amh', 'Amharic'), ('ara', 'Arabic'), ('asm', 'Assamese'), ('aze', 'Azerbaijani'),
+    ('aze_cyrl', 'Azerbaijani - Cyrillic'), ('bel', 'Belarusian'), ('ben', 'Bengali'), ('bod', 'Tibetan'),
+    ('bos', 'Bosnian'), ('bul', 'Bulgarian'), ('cat', 'Catalan; Valencian'), ('ceb', 'Cebuano'), ('ces', 'Czech'),
+    ('chi_sim', 'Chinese - Simplified'), ('chi_tra', 'Chinese - Traditional'), ('chr', 'Cherokee'), ('cym', 'Welsh'),
+    ('dan', 'Danish'), ('deu', 'German'), ('dzo', 'Dzongkha'), ('ell', 'Greek, Modern (1453-)'), ('eng', 'English'),
+    ('enm', 'English, Middle (1100-1500)'), ('epo', 'Esperanto'), ('est', 'Estonian'), ('eus', 'Basque'),
+    ('fas', 'Persian'), ('fin', 'Finnish'), ('fra', 'French'), ('frk', 'Frankish'),
+    ('frm', 'French, Middle (ca. 1400-1600)'), ('gle', 'Irish'), ('glg', 'Galician'), ('grc', 'Greek, Ancient (-1453)'),
+    ('guj', 'Gujarati'), ('hat', 'Haitian; Haitian Creole'), ('heb', 'Hebrew'), ('hin', 'Hindi'), ('hrv', 'Croatian'),
+    ('hun', 'Hungarian'), ('iku', 'Inuktitut'), ('ind', 'Indonesian'), ('isl', 'Icelandic'), ('ita', 'Italian'),
+    ('ita_old', 'Italian - Old'), ('jav', 'Javanese'), ('jpn', 'Japanese'), ('kan', 'Kannada'), ('kat', 'Georgian'),
+    ('kat_old', 'Georgian - Old'), ('kaz', 'Kazakh'), ('khm', 'Central Khmer'), ('kir', 'Kirghiz; Kyrgyz'),
+    ('kor', 'Korean'), ('kur', 'Kurdish'), ('lao', 'Lao'), ('lat', 'Latin'), ('lav', 'Latvian'), ('lit', 'Lithuanian'),
+    ('mal', 'Malayalam'), ('mar', 'Marathi'), ('mkd', 'Macedonian'), ('mlt', 'Maltese'), ('msa', 'Malay'),
+    ('mya', 'Burmese'), ('nep', 'Nepali'), ('nld', 'Dutch; Flemish'), ('nor', 'Norwegian'), ('ori', 'Oriya'),
+    ('pan', 'Panjabi; Punjabi'), ('pol', 'Polish'), ('por', 'Portuguese'), ('pus', 'Pushto; Pashto'),
+    ('ron', 'Romanian; Moldavian; Moldovan'), ('rus', 'Russian'), ('san', 'Sanskrit'), ('sin', 'Sinhala; Sinhalese'),
+    ('slk', 'Slovak'), ('slv', 'Slovenian'), ('spa', 'Spanish; Castilian'), ('spa_old', 'Spanish; Castilian - Old'),
+    ('sqi', 'Albanian'), ('srp', 'Serbian'), ('srp_latn', 'Serbian - Latin'), ('swa', 'Swahili'), ('swe', 'Swedish'),
+    ('syr', 'Syriac'), ('tam', 'Tamil'), ('tel', 'Telugu'), ('tgk', 'Tajik'), ('tgl', 'Tagalog'), ('tha', 'Thai'),
+    ('tir', 'Tigrinya'), ('tur', 'Turkish'), ('uig', 'Uighur; Uyghur'), ('ukr', 'Ukrainian'), ('urd', 'Urdu'),
+    ('uzb', 'Uzbek'), ('uzb_cyrl', 'Uzbek - Cyrillic'), ('vie', 'Vietnamese'), ('yid', 'Yiddish')
+]


### PR DESCRIPTION
### Added
- `/itt [-l LANG]` - Image to Text: Extract text from images
- `/itt_lang` - Languages for ItT: Available languages for Image to Text
- `/translate_image [TEXT] [-lf LANG] [-lt LANG]`  - Image to Text Translation: Extract text from images and translate it. `-lf` (default: detect, /itt_lang) language on image, to `-lt` (default: en, normal language codes) language.

### Changes
- Yandex translate got new function for itself, it is used by the `/translate` and `/itt_translate` command.
