### PR TITLE
Add /help alias for /comands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 2.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added an alias command ``/help`` for ``/commands``
 
 
 2.0.5 (2018-11-26)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Added an alias command ``/help`` for ``/commands``
+- Fixed usage alias commands overriding real commands
 
 
 2.0.5 (2018-11-26)

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ Base Group
 -  ``/support`` - Contact bot maintainer for support of any kind
 -  ``/contribute <text>`` - Send the supporters and admins a request of any kind
 -  ``/error <text>`` - If you have found an error please use this command.
+-  ``/help`` - Show all available commands
 
 Custom
 ^^^^^^

--- a/xenian/bot/commands/base.py
+++ b/xenian/bot/commands/base.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from telegram.ext import CallbackQueryHandler
 from telegram.ext import CommandHandler, Filters, MessageHandler
 
@@ -115,7 +117,7 @@ class BaseCommand:
             if not real_command:
                 continue
 
-            new_command = real_command.copy()
+            new_command = deepcopy(real_command)
             new_command['options']['command'] = alias_command['command_name']
             for key, value in alias_command.items():
                 if key in ['title', 'description', 'hidden', 'group', 'command_name']:

--- a/xenian/bot/commands/builtins.py
+++ b/xenian/bot/commands/builtins.py
@@ -20,6 +20,7 @@ class Builtins(BaseCommand):
         self.commands = [
             {'command': self.start, 'description': 'Initialize the bot'},
             {'command': self.commands, 'description': 'Show all available commands', 'options': {'pass_args': True}},
+            {'command_name': 'help', 'alias': 'commands'},
             {'command': self.support, 'description': 'Contact bot maintainer for support of any kind'},
             {'command': self.register, 'description': 'Register the chat_id for admins and supporters', 'hidden': True},
             {


### PR DESCRIPTION
This also fixes a problem with aliases overrideing the real commands. More info to that can be found in the commit itself.